### PR TITLE
feat: adiciona tela de editar perfil (UI)

### DIFF
--- a/NutriScan/NutriScan/Features/Edit Profile Screen/EditProfileView.swift
+++ b/NutriScan/NutriScan/Features/Edit Profile Screen/EditProfileView.swift
@@ -1,0 +1,102 @@
+//
+//  EditProfileView.swift
+//  NutriScan
+//
+//  Created by Matheus Abrahao Martins Alvares on 21/10/25.
+//
+
+import SwiftUI
+
+// View SwiftUI que desenha a tela de Editar Perfil
+struct EditProfileView: View {
+
+    // 1. Criamos e observamos o ViewModel
+    @StateObject private var viewModel = EditProfileViewModel()
+
+    var body: some View {
+        // ZStack para colocar a cor de fundo
+        ZStack {
+            Color.white.edgesIgnoringSafeArea(.all)
+
+            VStack(spacing: 20) { // VStack principal
+
+                // --- Título da Tela ---
+                Text("Editar perfil")
+                    .font(.semibold25)
+                    .foregroundColor(Color.neutral1)
+                    .frame(maxWidth: .infinity, alignment: .center) // Título centralizado
+                    .padding(.top, 20)
+
+                Spacer() // Empurra o conteúdo para o centro
+
+                // --- Campos de Texto ---
+                VStack(spacing: 16) {
+
+                    createTextField(label: "Nome:", text: $viewModel.nome)
+                    createTextField(label: "E-mail:", text: $viewModel.email, keyboard: .emailAddress)
+                    createTextField(label: "Telefone:", text: $viewModel.telefone, keyboard: .phonePad)
+
+                }
+                .padding(.horizontal, 30)
+
+                Spacer() // Empurra os botões para baixo
+
+                // --- Botões ---
+                VStack(spacing: 16) {
+                    Button(action: {
+                        viewModel.alterarSenha() // Chama a função do ViewModel
+                    }) {
+                        Text("Alterar senha")
+                            .font(.semibold17)
+                            .foregroundColor(.white)
+                            .padding()
+                            .frame(maxWidth: .infinity)
+                            .background(Color.primary1)
+                            .cornerRadius(12)
+                    }
+
+                    Button(action: {
+                        viewModel.salvarAlteracoes() // Chama a função do ViewModel
+                    }) {
+                        Text("Salvar")
+                            .font(.semibold17)
+                            .foregroundColor(.white)
+                            .padding()
+                            .frame(maxWidth: .infinity)
+                            .background(Color.primary1)
+                            .cornerRadius(12)
+                    }
+                }
+                .padding(.horizontal, 30)
+                .padding(.bottom, 40) // Espaço da parte de baixo
+            }
+            .padding()
+        }
+    }
+
+    // --- ViewBuilder para criar os campos de texto (reutilizado) ---
+    // (Exatamente o mesmo da tela de Cadastro)
+    @ViewBuilder
+    private func createTextField(label: String, text: Binding<String>, keyboard: UIKeyboardType = .default) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label)
+                .font(.regular17)
+                .foregroundColor(Color.neutral2) // Label cinza
+
+            TextField("", text: text) // Placeholder vazio
+                .font(.regular17)
+                .padding(16)
+                .background(Color.primary3) // Fundo verde claro
+                .cornerRadius(12)
+                .keyboardType(keyboard)
+                .autocapitalization(.none)
+        }
+    }
+}
+
+// --- Preview ---
+struct EditProfileView_Previews: PreviewProvider {
+    static var previews: some View {
+        EditProfileView()
+    }
+}

--- a/NutriScan/NutriScan/Features/Edit Profile Screen/EditProfileViewModel.swift
+++ b/NutriScan/NutriScan/Features/Edit Profile Screen/EditProfileViewModel.swift
@@ -1,0 +1,32 @@
+//
+//  EditProfileViewModel.swift
+//  NutriScan
+//
+//  Created by Matheus Abrahao Martins Alvares on 21/10/25.
+//
+
+import Foundation
+import Combine
+
+// O ViewModel para a tela de Editar Perfil.
+// Apenas guarda o estado dos campos.
+class EditProfileViewModel: ObservableObject {
+
+    // @Published para cada campo do formulário
+    // Desta vez, iniciamos com dados de exemplo (como no design)
+    @Published var nome = "Katherine Pierce"
+    @Published var email = "katherine.pierce@icloud.com"
+    @Published var telefone = "(11) 99899-9877"
+
+    // Funções de lógica vazias
+
+    func salvarAlteracoes() {
+        // Sem lógica por enquanto
+        print("Botão 'Salvar' clicado - (Lógica a implementar)")
+    }
+
+    func alterarSenha() {
+        // Sem lógica por enquanto
+        print("Botão 'Alterar senha' clicado - (Lógica a implementar)")
+    }
+}


### PR DESCRIPTION
Aqui está a última tela que faltava: "Editar Perfil".

Segui o mesmo padrão de SwiftUI puro com MVVM das telas de Login e Cadastro. A UI foi feita com base no design e o `EditProfileViewModel` está com as funções de lógica vazias (só com `print()`).