### PR TITLE
Feat/compare foods

### DIFF
--- a/NutriScan/NutriScan.xcodeproj/xcuserdata/raphavidall.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/NutriScan/NutriScan.xcodeproj/xcuserdata/raphavidall.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>NutriScan.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/NutriScan/NutriScan/Components/FoodInformationItem/FoodInformationItemView.swift
+++ b/NutriScan/NutriScan/Components/FoodInformationItem/FoodInformationItemView.swift
@@ -21,9 +21,10 @@ struct FoodInformationItemView: View {
                 Text(foodInformation.brand)
                     .foregroundStyle(.neutralColor2)
             }
+            
             Spacer()
+            
             NumberScoreView(numberScore: foodInformation.score)
-            Image(systemName: "chevron.right")
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 10)
@@ -32,9 +33,11 @@ struct FoodInformationItemView: View {
 
 #Preview {
     guard let url = URL(string: "https://placehold.co/60") else { return EmptyView() }
-    let foodInformation = FoodInformation(name: "Leite condensado",
-                                          brand: "Italac",
-                                          imageUrl: url,
-                                          score: .scoreE)
+    let foodInformation = FoodInformation(
+        name: "Leite condensado",
+        brand: "Italac",
+        imageUrl: url,
+        score: .scoreE
+    )
     return FoodInformationItemView(foodInformation: foodInformation)
 }

--- a/NutriScan/NutriScan/Components/FoodInformationItem/Models/FoodInformation.swift
+++ b/NutriScan/NutriScan/Components/FoodInformationItem/Models/FoodInformation.swift
@@ -6,7 +6,8 @@
 //
 import Foundation
 
-struct FoodInformation {
+struct FoodInformation: Identifiable, Hashable {
+    var id = UUID()
     let name: String
     let brand: String
     let imageUrl: URL

--- a/NutriScan/NutriScan/Features/CompareFoods/CompareFoodsViewModel.swift
+++ b/NutriScan/NutriScan/Features/CompareFoods/CompareFoodsViewModel.swift
@@ -1,0 +1,49 @@
+//
+//  CompareFoodsViewModel.swift
+//  NutriScan
+//
+//  Created by Rapha Vidal on 23/10/25.
+//
+
+import Foundation
+import Combine
+
+class CompareFoodsViewModel: ObservableObject {
+    @Published var productOne: FoodInformation
+    @Published var productTwo: FoodInformation?
+    
+    var isReadyForComparison: Bool {
+        productTwo != nil
+    }
+    
+    init(productOne: FoodInformation) {
+        self.productOne = productOne
+        self.productTwo = nil
+    }
+    
+    // Chamado pela tela de Scan ou Busca quando um produto é selecionado.
+    func setProductForComparison(_ food: FoodInformation) {
+        DispatchQueue.main.async {
+            self.productTwo = food
+        }
+    }
+    
+    // remover o segundo produto e escolher outro (voltar para o Scan/Busca).
+    func removeProductForComparison() {
+        DispatchQueue.main.async {
+            self.productTwo = nil
+        }
+    }
+    
+    // Trocar o produto "A" pelo "B"
+    func swapProducts() {
+        guard let productTwo = self.productTwo else { return }
+        
+        let tempProduct = self.productOne
+        
+        DispatchQueue.main.async {
+            self.productOne = productTwo
+            self.productTwo = tempProduct
+        }
+    }
+}

--- a/NutriScan/NutriScan/Features/CompareFoods/Components/ProductCompareColumn.swift
+++ b/NutriScan/NutriScan/Features/CompareFoods/Components/ProductCompareColumn.swift
@@ -1,0 +1,74 @@
+//
+//  ProductCompareColumn.swift
+//  NutriScan
+//
+//  Created by Rapha Vidal on 23/10/25.
+//
+import SwiftUI
+
+struct ProductCompareColumn: View {
+    
+    let product: FoodInformation
+    var isSecondProduct: Bool = false
+    var onRemove: (() -> Void)?
+    
+    let mockInfoItems: [InfoItem] = [
+        .init(icon: .system(name: .heart), foregroundColor: .icon2,  title: "Bom para o coração", subtitle: "Baixo em gordura: 2,80g", backgroundColor: .iconBackground),
+        .init(icon: .asset(name: .muscleArm), foregroundColor: nil, title: "Construção de Ossos e Músculos", subtitle: "Alto em proteínas: 14g", backgroundColor: .secondary3)
+    ]
+    
+    var body: some View {
+        VStack(spacing: 16) {
+            AsyncImage(url: product.imageUrl) { $0.resizable().scaledToFit() }
+                placeholder: { Color.gray.opacity(0.1) }
+                .frame(height: 100)
+            
+            Text(product.name)
+                .font(.headline)
+                .multilineTextAlignment(.center)
+            Text(product.brand)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            
+            Divider()
+            
+            VStack(alignment: .leading, spacing: 12) {
+                // TODO: Você precisa buscar os InfoItems reais do produto
+                // Esta é uma recriação simplificada do seu layout
+                // Você deve usar seu 'DetailsView' ou sua lógica aqui
+                ForEach(mockInfoItems, id: \.title) { item in
+                    HStack {
+                        // TODO: Reconstrua sua IconCircleView aqui
+                        Image(systemName: "heart.fill") // Placeholder
+                            .foregroundColor(item.foregroundColor)
+                            .padding(8)
+                            .background(item.backgroundColor)
+                            .clipShape(Circle())
+                        
+                        VStack(alignment: .leading) {
+                            Text(item.title).font(.caption.bold())
+                            Text(item.subtitle).font(.caption2)
+                        }
+                    }
+                }
+            }
+            
+            NutriScoreView(selectedScore: product.score)
+            
+            // Botão de Favoritos (Lógica mockada)
+            
+            
+            // Botão de Remover (só aparece para o produto 2)
+            if let onRemove = onRemove {
+                Button(action: onRemove) {
+                    Text("Remover Produto")
+                        .font(.caption)
+                }
+                .tint(.red)
+            } else {
+                // Espaçador para manter a altura igual
+                Button("") {}.font(.caption).hidden()
+            }
+        }
+    }
+}

--- a/NutriScan/NutriScan/Features/CompareFoods/Views/CompareFoodContainerView.swift
+++ b/NutriScan/NutriScan/Features/CompareFoods/Views/CompareFoodContainerView.swift
@@ -1,0 +1,72 @@
+//
+//  CompareFoodRootView.swift
+//  NutriScan
+//
+//  Created by Rapha Vidal on 23/10/25.
+//
+
+import SwiftUI
+
+import SwiftUI
+
+struct CompareFoodContainerView: View {
+    @StateObject private var viewModel: CompareFoodsViewModel
+    
+    init(productOne: FoodInformation) {
+        _viewModel = StateObject(wrappedValue: CompareFoodsViewModel(productOne: productOne))
+    }
+    
+    var body: some View {
+        
+        if viewModel.isReadyForComparison {
+            CompareFoodView(viewModel: viewModel)
+        } else {
+            SelectSecondProductView(viewModel: viewModel)
+        }
+    }
+}
+
+struct SearchFoodViewWithCallback: View {
+    
+    @StateObject private var viewModel = SearchFoodsViewModel()
+    
+    var onSelected: (FoodInformation) -> Void
+    
+    var body: some View {
+        NavigationView {
+            List(viewModel.filteredProducts) { foodInfo in
+                // Em vez de NavigationLink, usamos um Button
+                Button(action: {
+                    // Chama o callback com o produto selecionado
+                    onSelected(foodInfo)
+                }) {
+                    // Reutiliza sua view de item
+                    FoodInformationItemView(foodInformation: foodInfo)
+                        // Botões dentro de Listas podem mudar a cor
+                        // do texto, então forçamos a cor primária.
+                        .foregroundColor(.primary)
+                }
+                .listRowInsets(EdgeInsets())
+            }
+            .listStyle(.plain)
+            .navigationTitle("Buscar Produto")
+            .navigationBarTitleDisplayMode(.inline)
+            .searchable(text: $viewModel.searchText, prompt: viewModel.prompt)
+        }
+    }
+}
+
+struct ScannerViewPlaceholder: View {
+    var onFound: (FoodInformation) -> Void
+    @Environment(\.dismiss) var dismiss
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Scanner Placeholder")
+            Button("Simular Scan (Oreo)") {
+                let oreo = FoodInformation(name: "Bolacha Recheada", brand: "Oreo", imageUrl: URL(string: "https://placehold.co/60?text=Bolacha")!, score: .scoreE)
+                onFound(oreo)
+            }
+            Button("Cancelar") { dismiss() }
+        }
+    }
+}

--- a/NutriScan/NutriScan/Features/CompareFoods/Views/CompareFoodView.swift
+++ b/NutriScan/NutriScan/Features/CompareFoods/Views/CompareFoodView.swift
@@ -1,0 +1,44 @@
+//
+//  CompareFoodView.swift
+//  NutriScan
+//
+//  Created by Rapha Vidal on 23/10/25.
+//
+import SwiftUI
+
+struct CompareFoodView: View {
+    
+    @ObservedObject var viewModel: CompareFoodsViewModel
+    
+    var body: some View {
+        ScrollView {
+            VStack {
+                HStack(alignment: .top, spacing: 16) {
+                    ProductCompareColumn(product: viewModel.productOne, onRemove: nil)
+                    
+                    if let productTwo = viewModel.productTwo {
+                        ProductCompareColumn(
+                            product: productTwo,
+                            onRemove: {
+                                // Ação para remover o produto 2
+                                viewModel.removeProductForComparison()
+                            }
+                        )
+                    }
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("Comparação")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: {
+                    viewModel.swapProducts()
+                }) {
+                    Image(systemName: "arrow.left.arrow.right.circle")
+                }
+            }
+        }
+    }
+}

--- a/NutriScan/NutriScan/Features/CompareFoods/Views/SelectSecondProductView.swift
+++ b/NutriScan/NutriScan/Features/CompareFoods/Views/SelectSecondProductView.swift
@@ -1,0 +1,136 @@
+//
+//  SelectSecondProductView.swift
+//  NutriScan
+//
+//  Created by Rapha Vidal on 23/10/25.
+//
+import SwiftUI
+
+struct SelectSecondProductView: View {
+    @ObservedObject var viewModel: CompareFoodsViewModel
+    
+    var body: some View {
+        VStack(spacing: 30) {
+            Text("Selecione o segundo produto")
+                .font(.title2)
+                .fontWeight(.bold)
+            
+            Text("Você está comparando com:")
+                .font(.headline)
+            
+            FoodInformationItemView(foodInformation: viewModel.productOne)
+                .padding()
+                .background(Color(.systemGray6))
+                .cornerRadius(12)
+                .padding(.horizontal)
+            
+            Spacer()
+            
+            NavigationLink(destination: ScanSecondProductView(compareViewModel: viewModel)) {
+                Label("Escanear Produto", systemImage: "barcode.viewfinder")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.accentColor)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+            }
+            .padding(.horizontal)
+            
+            NavigationLink(destination: SearchSecondProductView(compareViewModel: viewModel)) {
+                Label("Buscar Produto", systemImage: "magnifyingglass")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.gray.opacity(0.2))
+                    .foregroundColor(.accentColor)
+                    .cornerRadius(10)
+            }
+            .padding(.horizontal)
+            Spacer()
+        }
+        .padding(.top, 40)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+struct SearchSecondProductView: View {
+    @StateObject private var searchViewModel = SearchFoodsViewModel()
+    
+    @ObservedObject var compareViewModel: CompareFoodsViewModel
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            
+            ProductSummaryCard(product: compareViewModel.productOne)
+            
+            List(searchViewModel.filteredProducts) { foodInfo in
+                Button(action: {
+                    compareViewModel.setProductForComparison(foodInfo)
+                }) {
+                    FoodInformationItemView(foodInformation: foodInfo)
+                        .foregroundColor(.primary)
+                }
+                .listRowInsets(EdgeInsets())
+            }
+            .listStyle(.plain)
+        }
+        .navigationTitle("Buscar Produto")
+        .navigationBarTitleDisplayMode(.inline)
+        .searchable(text: $searchViewModel.searchText, prompt: searchViewModel.prompt)
+    }
+}
+
+struct ProductSummaryCard: View {
+    
+    let product: FoodInformation
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Comparando com:")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            
+            HStack {
+                AsyncImage(url: product.imageUrl) { $0.resizable().scaledToFit() }
+                    placeholder: { Color.gray.opacity(0.1) }
+                    .frame(width: 30, height: 30)
+                    .cornerRadius(4)
+                
+                VStack(alignment: .leading) {
+                    Text(product.name).font(.subheadline).bold()
+                    Text(product.brand).font(.caption).foregroundColor(.secondary)
+                }
+                Spacer()
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
+        .background(Color(.systemGray5))
+    }
+}
+
+struct ScanSecondProductView: View {
+    
+    @ObservedObject var compareViewModel: CompareFoodsViewModel
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            
+            ProductSummaryCard(product: compareViewModel.productOne)
+            Spacer()
+            
+            Text("ScannerView")
+            Spacer()
+            
+            Button("Simular Scan (Oreo)") {
+                let oreo = FoodInformation(name: "Bolacha Recheada", brand: "Oreo", imageUrl: URL(string: "https://placehold.co/60?text=Bolacha")!, score: .scoreE)
+                
+                compareViewModel.setProductForComparison(oreo)
+            }
+            .padding()
+        }
+        .navigationTitle("Escanear Produto")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/NutriScan/NutriScan/Features/Details/DetailsViewController.swift
+++ b/NutriScan/NutriScan/Features/Details/DetailsViewController.swift
@@ -14,17 +14,11 @@ class DetailsViewController: UIViewController {
     private let contentView = DetailsView()
     
     
-    private var productTitle: String
-    private var brand: String
-    private var imageURL: URL?
-    private var score: NumberScore
+    private var foodInfo: FoodInformation
     private var infoItems: [InfoItem]
     
-    init(title: String, brand: String, imageURL: URL?, score: NumberScore, infoItem: [InfoItem]) {
-        self.productTitle = title
-        self.brand = brand
-        self.imageURL = imageURL
-        self.score = score
+    init(foodInfo: FoodInformation, infoItem: [InfoItem]) {
+        self.foodInfo = foodInfo
         self.infoItems = infoItem
         super.init(nibName: nil, bundle: nil)
     }
@@ -37,6 +31,11 @@ class DetailsViewController: UIViewController {
         super.viewDidLoad()
         setupLayout()
         configure()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: animated)
     }
 }
 
@@ -68,12 +67,32 @@ extension DetailsViewController {
     
     private func configure() {
         contentView.configure(
-            imageURL: imageURL,
-            productTitle: productTitle,
-            brand: brand,
-            score: score,
+            imageURL: foodInfo.imageUrl,
+            productTitle: foodInfo.name,
+            brand: foodInfo.brand,
+            score: foodInfo.score,
             infoItems: infoItems
         )
+        
+        contentView.onCompareButtonTapped = { [weak self] in
+            self?.presentCompareScreen()
+        }
+    }
+    
+    private func presentCompareScreen() {
+        guard let navigationController = self.navigationController else {
+            print("Erro: DetailsViewController não está em um Navigation Controller.")
+            return
+        }
+        
+        let compareView = CompareFoodContainerView(productOne: self.foodInfo)
+        
+        let hostingController = UIHostingController(
+            rootView: NavigationView { compareView }
+        )
+        
+        navigationController.setNavigationBarHidden(true, animated: true)
+        navigationController.pushViewController(hostingController, animated: true)
     }
 }
 
@@ -86,11 +105,8 @@ struct DetailsViewControllerWrapper: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> DetailsViewController {
         
         return DetailsViewController(
-            title: foodInfo.name,           // <--- Alterado
-            brand: foodInfo.brand,          // <--- Alterado
-            imageURL: foodInfo.imageUrl,    // <--- Alterado
-            score: foodInfo.score,          // <--- Alterado
-            infoItem: [ // Mantive seus dados fixos, pois eles não vêm do 'foodInfo'
+            foodInfo: foodInfo,
+            infoItem: [
                 .init(icon: .system(name: .heart), foregroundColor: .icon2,  title: "Bom para o coração", subtitle: "Baixo em gordura: 2,80g", backgroundColor: .iconBackground),
                 .init(icon: .asset(name: .muscleArm), foregroundColor: nil, title: "Construção de Ossos e Músculos", subtitle: "Alto em proteínas: 14g", backgroundColor: .secondary3),
                 .init(icon: .asset(name: .intestine), foregroundColor: nil, title: "Auxilia no funcionamento do intestino", subtitle: "Rico em fibras: 10g", backgroundColor: .secondary1),

--- a/NutriScan/NutriScan/Features/Details/DetailsViewController.swift
+++ b/NutriScan/NutriScan/Features/Details/DetailsViewController.swift
@@ -80,16 +80,25 @@ extension DetailsViewController {
 struct DetailsViewControllerWrapper: UIViewControllerRepresentable {
     
     typealias UIViewControllerType = DetailsViewController
-
+    
+    let foodInfo: FoodInformation
+    
     func makeUIViewController(context: Context) -> DetailsViewController {
-        return DetailsViewController(title: "Biscoite Recheado", brand: "Trakinas", imageURL: URL(string: "https://placehold.co/60")!, score: .scoreE, infoItem: [
-            .init(icon: .system(name: .heart), foregroundColor: .icon2,  title: "Bom para o coração", subtitle: "Baixo em gordura: 2,80g", backgroundColor: .iconBackground),
-            .init(icon: .asset(name: .muscleArm), foregroundColor: nil, title: "Construção de Ossos e Músculos", subtitle: "Alto em proteínas: 14g", backgroundColor: .secondary3),
-            .init(icon: .asset(name: .intestine), foregroundColor: nil, title: "Auxilia no funcionamento do intestino", subtitle: "Rico em fibras: 10g", backgroundColor: .secondary1),
-            .init(icon: .system(name: .checkmark), foregroundColor: .icon1, title: "Lactose", subtitle: "Zero em lactose", backgroundColor: .primary1)
-        ])
+        
+        return DetailsViewController(
+            title: foodInfo.name,           // <--- Alterado
+            brand: foodInfo.brand,          // <--- Alterado
+            imageURL: foodInfo.imageUrl,    // <--- Alterado
+            score: foodInfo.score,          // <--- Alterado
+            infoItem: [ // Mantive seus dados fixos, pois eles não vêm do 'foodInfo'
+                .init(icon: .system(name: .heart), foregroundColor: .icon2,  title: "Bom para o coração", subtitle: "Baixo em gordura: 2,80g", backgroundColor: .iconBackground),
+                .init(icon: .asset(name: .muscleArm), foregroundColor: nil, title: "Construção de Ossos e Músculos", subtitle: "Alto em proteínas: 14g", backgroundColor: .secondary3),
+                .init(icon: .asset(name: .intestine), foregroundColor: nil, title: "Auxilia no funcionamento do intestino", subtitle: "Rico em fibras: 10g", backgroundColor: .secondary1),
+                .init(icon: .system(name: .checkmark), foregroundColor: .icon1, title: "Lactose", subtitle: "Zero em lactose", backgroundColor: .primary1)
+            ]
+        )
     }
-
+    
     func updateUIViewController(_ uiViewController: DetailsViewController, context: Context) {
         
     }

--- a/NutriScan/NutriScan/Features/Details/View/DetailsView.swift
+++ b/NutriScan/NutriScan/Features/Details/View/DetailsView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 
 class DetailsView: UIView {
 
+    var onCompareButtonTapped: (() -> Void)?
+    
     private let productImageView: UIImageView = {
         let imageView = UIImageView(image: .onboarding1)
         imageView.contentMode = .scaleAspectFit
@@ -71,6 +73,13 @@ class DetailsView: UIView {
         setupLayout()
         setButtonConfiguration(button: favoriteButton, title: "Salvar nos Favoritos", image: UIImage(systemName: "heart"))
         setButtonConfiguration(button: compareButton, title: "Comparar Produto")
+        
+        compareButton.addTarget(self, action: #selector(handleCompareTap), for: .touchUpInside)
+    }
+    
+    @objc private func handleCompareTap() {
+        // 4. CHAME O CALLBACK
+        onCompareButtonTapped?()
     }
     
     required init? (coder: NSCoder) {

--- a/NutriScan/NutriScan/Features/Favorites/FavoriteViewController.swift
+++ b/NutriScan/NutriScan/Features/Favorites/FavoriteViewController.swift
@@ -31,7 +31,7 @@ class FavoriteViewController: UIViewController {
         )
         return tableView
     }()
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setupView()
@@ -46,7 +46,7 @@ class FavoriteViewController: UIViewController {
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
     }
-
+    
 }
 
 extension FavoriteViewController: UITableViewDataSource {
@@ -59,7 +59,7 @@ extension FavoriteViewController: UITableViewDataSource {
             return UITableViewCell()
         }
         
-                let item = informationData[indexPath.row]
+        let item = informationData[indexPath.row]
         
         if #available(iOS 16.0, *) {
             cell.contentConfiguration = UIHostingConfiguration {
@@ -74,12 +74,18 @@ extension FavoriteViewController: UITableViewDataSource {
 extension FavoriteViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        let detailVC = DetailsViewController(title: informationData[indexPath.row].name, brand: informationData[indexPath.row].brand, imageURL: informationData[indexPath.row].imageUrl, score: informationData[indexPath.row].score, infoItem: [
-            .init(icon: .system(name: .heart), foregroundColor: .icon2,  title: "Bom para o coração", subtitle: "Baixo em gordura: 2,80g", backgroundColor: .iconBackground),
-            .init(icon: .asset(name: .muscleArm), foregroundColor: nil, title: "Construção de Ossos e Músculos", subtitle: "Alto em proteínas: 14g", backgroundColor: .secondary3),
-            .init(icon: .asset(name: .intestine), foregroundColor: nil, title: "Auxilia no funcionamento do intestino", subtitle: "Rico em fibras: 10g", backgroundColor: .secondary1),
-            .init(icon: .system(name: .checkmark), foregroundColor: .icon1, title: "Lactose", subtitle: "Zero em lactose", backgroundColor: .primary1)
-        ])
+        let detailVC = DetailsViewController(
+            foodInfo: FoodInformation(
+                name: informationData[0].name,
+                brand: informationData[0].brand,
+                imageUrl: informationData[0].imageUrl,
+                score: informationData[0].score),
+            infoItem: [
+                .init(icon: .system(name: .heart), foregroundColor: .icon2,  title: "Bom para o coração", subtitle: "Baixo em gordura: 2,80g", backgroundColor: .iconBackground),
+                .init(icon: .asset(name: .muscleArm), foregroundColor: nil, title: "Construção de Ossos e Músculos", subtitle: "Alto em proteínas: 14g", backgroundColor: .secondary3),
+                .init(icon: .asset(name: .intestine), foregroundColor: nil, title: "Auxilia no funcionamento do intestino", subtitle: "Rico em fibras: 10g", backgroundColor: .secondary1),
+                .init(icon: .system(name: .checkmark), foregroundColor: .icon1, title: "Lactose", subtitle: "Zero em lactose", backgroundColor: .primary1)
+            ])
         present(detailVC, animated: true)
     }
 }
@@ -87,11 +93,11 @@ extension FavoriteViewController: UITableViewDelegate {
 struct FavoriteViewControllerWrapper: UIViewControllerRepresentable {
     
     typealias UIViewControllerType = FavoriteViewController
-
+    
     func makeUIViewController(context: Context) -> FavoriteViewController {
         return FavoriteViewController()
     }
-
+    
     func updateUIViewController(_ uiViewController: FavoriteViewController, context: Context) {
         
     }

--- a/NutriScan/NutriScan/Features/SearchFoods/SearchFoodView.swift
+++ b/NutriScan/NutriScan/Features/SearchFoods/SearchFoodView.swift
@@ -1,0 +1,29 @@
+//
+//  Untitled.swift
+//  NutriScan
+//
+//  Created by Rapha Vidal on 23/10/25.
+//
+
+import SwiftUI
+
+struct SearchFoodView: View {
+    @StateObject private var viewModel = SearchFoodsViewModel()
+    
+    let title: String = "Busca"
+    
+    var body: some View {
+        List(viewModel.filteredProducts) { foodInfo in
+            FoodInformationItemView(foodInformation: foodInfo)
+                .listRowInsets(EdgeInsets())
+        }
+        .listStyle(.plain)
+        .navigationTitle("Busca")
+        .navigationBarTitleDisplayMode(.inline)
+        .searchable(text: $viewModel.searchText, prompt: viewModel.prompt)
+    }
+}
+
+#Preview {
+    SearchFoodView()
+}

--- a/NutriScan/NutriScan/Features/SearchFoods/SearchFoodView.swift
+++ b/NutriScan/NutriScan/Features/SearchFoods/SearchFoodView.swift
@@ -10,13 +10,20 @@ import SwiftUI
 struct SearchFoodView: View {
     @StateObject private var viewModel = SearchFoodsViewModel()
     
-    let title: String = "Busca"
-    
     var body: some View {
         List(viewModel.filteredProducts) { foodInfo in
-            FoodInformationItemView(foodInformation: foodInfo)
-                .listRowInsets(EdgeInsets())
+            NavigationLink(
+                destination:
+                    DetailsViewControllerWrapper(foodInfo: foodInfo)
+                    .ignoresSafeArea()
+                    .navigationTitle("Detalhes do Produto")
+                    .navigationBarTitleDisplayMode(.inline)
+            ){
+                FoodInformationItemView(foodInformation: foodInfo)
+            }
+            .listRowInsets(EdgeInsets())
         }
+        .padding(.horizontal)
         .listStyle(.plain)
         .navigationTitle("Busca")
         .navigationBarTitleDisplayMode(.inline)

--- a/NutriScan/NutriScan/Features/SearchFoods/SearchFoodsViewModel.swift
+++ b/NutriScan/NutriScan/Features/SearchFoods/SearchFoodsViewModel.swift
@@ -1,0 +1,43 @@
+//
+//  SearchFoodsViewModel.swift
+//  NutriScan
+//
+//  Created by Rapha Vidal on 23/10/25.
+//
+
+import Foundation
+import Combine
+
+class SearchFoodsViewModel: ObservableObject {
+    @Published var allFoods: [FoodInformation] = []
+    
+    @Published var searchText = ""
+    
+    let prompt: String = "Digite o nome ou marca"
+    
+    var filteredProducts: [FoodInformation] {
+        if searchText.isEmpty {
+            return allFoods
+        } else {
+            return allFoods.filter {
+                $0.name.localizedCaseInsensitiveContains(searchText) ||
+                $0.brand.localizedCaseInsensitiveContains(searchText)
+            }
+        }
+    }
+    
+    init() {
+        loadMockData()
+    }
+    
+    func loadMockData() {
+        self.allFoods = [
+            FoodInformation(name: "Leite condensado", brand: "Italac", imageUrl: URL(string: "https://placehold.co/60?text=Leite")!, score: .scoreE),
+            FoodInformation(name: "Iogurte Grego", brand: "Vigor", imageUrl: URL(string: "https://placehold.co/60?text=Iogurte")!, score: .scoreB),
+            FoodInformation(name: "Peito de Frango", brand: "Sadia", imageUrl: URL(string: "https://placehold.co/60?text=Frango")!, score: .scoreA),
+            FoodInformation(name: "Bolacha Recheada", brand: "Oreo", imageUrl: URL(string: "https://placehold.co/60?text=Bolacha")!, score: .scoreE),
+            FoodInformation(name: "Arroz Integral", brand: "Tio João", imageUrl: URL(string: "https://placehold.co/60?text=Arroz")!, score: .scoreA),
+            FoodInformation(name: "Atum em Óleo", brand: "Coqueiro", imageUrl: URL(string: "https://placehold.co/60?text=Atum")!, score: .scoreC)
+        ]
+    }
+}

--- a/NutriScan/NutriScan/RootView.swift
+++ b/NutriScan/NutriScan/RootView.swift
@@ -20,17 +20,14 @@ struct RootView: View {
                     Text("Home")
                         .padding()
                     Spacer()
-    //                HomeRootView()
+    //              HomeRootView()
                 case .search:
-                    Text("Busca")
-                        .padding()
-                    Spacer()
-    //                SearchRootView()
+                    SearchFoodView()
                 case .scan:
                     Text("Scaner")
                         .padding()
                     Spacer()
-    //                ScanRootView()
+    //              ScanRootView()
                 case .favorites:
                     FavoriteRootView()
                         .navigationTitle(Text("Favoritos"))


### PR DESCRIPTION
feat(compare): Implementa fluxo de navegação da tela de Detalhes

Este commit introduz a nova feature "Comparar Produtos", iniciando o fluxo a partir da tela de Detalhes (UIKit).

O DetailsViewController foi modificado para detectar o toque no botão "Comparar" (via um callback da DetailsView). Ao ser tocado, ele agora:

Cria a nova CompareFoodContainerView (SwiftUI).
Injeta o productOne (o produto atual) no CompareFoodsViewModel.
Envolve a view SwiftUI em um UIHostingController e a "empurra" (push) na pilha de navegação.
A feature CompareFoods (SwiftUI) gerencia seu próprio fluxo de navegação:

CompareFoodContainerView atua como o controlador de fluxo.
SelectSecondProductView (tela intermediária) apresenta NavigationLinks para as telas de Scan e Busca.
ScanSecondProductView e SearchSecondProductView recebem a compareViewModel e exibem um ProductSummaryCard (card de resumo) no topo.
Quando um produto é selecionado (via scan ou busca), a compareViewModel é atualizada, e o CompareFoodContainerView automaticamente troca a view para a CompareFoodView final.
BUG CONHECIDO (WIP):

Atualmente, as telas "Escanear Produto" e "Buscar Produto" exibem uma barra de navegação duplicada (double toolbar).

Isso ocorre devido a um conflito entre o UINavigationController (UIKit) da tela de Detalhes e a NavigationView (SwiftUI) que foi adicionada no UIHostingController para gerenciar o fluxo interno da feature de comparação. A tentativa de usar setNavigationBarHidden(true) não foi totalmente eficaz e precisa ser revista.