### PR TITLE
fix: corrige posicionamento da barra de busca no iOS 17/18

### DIFF
--- a/NutriScan/NutriScan/Features/SearchFoods/SearchFoodView.swift
+++ b/NutriScan/NutriScan/Features/SearchFoods/SearchFoodView.swift
@@ -45,7 +45,7 @@ struct SearchFoodView: View {
         )
         .navigationTitle("Busca")
         .navigationBarTitleDisplayMode(.inline)
-        .searchable(text: $viewModel.searchText, prompt: viewModel.prompt)
+        .searchable(text: $viewModel.searchText, prompt: viewModel.prompt, placement: .navigationBarDrawer(displayMode: .always))
     }
 }
 

--- a/NutriScan/NutriScan/MainRootView.swift
+++ b/NutriScan/NutriScan/MainRootView.swift
@@ -13,12 +13,13 @@ struct MainRootView: View {
     var body: some View {
         
         NavigationView {
-            VStack {
+            VStack(spacing: 0) {
                 switch router.selectedTab {
                 case .home:
                     HomeRootView()
                 case .search:
                     SearchFoodView()
+                        .ignoresSafeArea(edges: .bottom)
                 case .scan:
                     ScanRootView()
                 case .favorites:
@@ -28,7 +29,9 @@ struct MainRootView: View {
                 }
                 CustomTabBarView(selectedTab: $router.selectedTab)
             }
+            .ignoresSafeArea(.keyboard)
         }
+        .navigationViewStyle(.stack)
     }
 }
 


### PR DESCRIPTION
Resolve problema onde a search bar aparecia sobreposta ao TabBar ou oculta atrás da navigation bar em dispositivos iOS 17/18.

Mudanças:
- Adiciona placement .navigationBarDrawer(displayMode: .always) no .searchable() para fixar posição
- Ajusta VStack com spacing: 0 para prevenir espaçamento indesejado
- Adiciona .ignoresSafeArea(edges: .bottom) na SearchFoodView
- Adiciona .navigationViewStyle(.stack) para comportamento consistente
- Adiciona .ignoresSafeArea(.keyboard) para prevenir layout shift no teclado